### PR TITLE
adding 2.4rc1 and template for future RCs

### DIFF
--- a/envs/pyspark-340-delta-240rc1.yml
+++ b/envs/pyspark-340-delta-240rc1.yml
@@ -1,0 +1,21 @@
+name: pyspark-340-delta-240rc1
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.9
+  - ipykernel
+  - nb_conda
+  - jupyterlab
+  - jupyterlab_code_formatter
+  - isort
+  - black
+  - pytest
+  - pyspark=3.4.0
+  #- delta-spark==2.3.0
+  - pip
+  - pip:
+    - quinn
+    - chispa
+    - --extra-index-url https://test.pypi.org/simple/
+    - delta-spark==2.4.0rc1

--- a/ivy/2.4.0rc1.xml
+++ b/ivy/2.4.0rc1.xml
@@ -1,0 +1,12 @@
+<ivysettings>
+  <settings defaultResolver="mychain" />
+  <resolvers>
+    <ibiblio name="custom" m2compatible="true" root="https://oss.sonatype.org/content/repositories/iodelta-1080/" />
+    <ibiblio name="central" m2compatible="true"/>
+    <chain name="mychain">
+      <resolver ref="custom"/>
+      <resolver ref="central"/>
+    </chain>
+  </resolvers>
+</ivysettings>
+


### PR DESCRIPTION
Adding ability/template to run release candidates.

This requires adding an Ivy settings file and modifying the environment yml file to use an alternate index for resolving the python dependency.

In a notebook you pass the Ivy settings file like so,

```
.config(
        "spark.jars.ivySettings",
        "../../ivy/2.4.0rc1.xml"
    )
```

We can keep this internal for now and add some documentation later if necessary in a separate PR? Let me know.