### PR TITLE
removes nb_conda from deltalake-0100 conda env

### DIFF
--- a/envs/deltalake-0100.yml
+++ b/envs/deltalake-0100.yml
@@ -7,7 +7,6 @@ dependencies:
   - ipykernel
   - pandas=1.5.3
   - ibis-framework
-  - nb_conda
   - jupyterlab
   - jupyterlab_code_formatter
   - isort


### PR DESCRIPTION
the `nb_conda` dependency was causing the environment build to fail. This PR removes that dependency.