### PR TITLE
Add delta-without-spark example notebook

### DIFF
--- a/notebooks/python-deltalake/delta-lake-without-spark.ipynb
+++ b/notebooks/python-deltalake/delta-lake-without-spark.ipynb
@@ -1,0 +1,1260 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fa142e81-2c7f-4769-a630-0db4bf7a5b3e",
+   "metadata": {},
+   "source": [
+    "# Using Delta Lake without Spark\n",
+    "\n",
+    "This notebook shows you how to use Delta Lake without Spark, by using the [delta-rs](https://delta-io.github.io/delta-rs/) package.\n",
+    "\n",
+    "You might want to use Delta Lake without Spark because:\n",
+    "- You don’t want to learn Spark\n",
+    "- Your team doesn’t use Spark\n",
+    "- You don’t want to use the Java Virtual Machine (JVM) \n",
+    "- You are working with relatively small datasets\n",
+    "\n",
+    "There are many ways to use Delta Lake without Spark. \n",
+    "\n",
+    "Let’s group them into two categories for clarity:\n",
+    "\n",
+    "1. dedicated Delta Connectors let you use Delta Lake from engines like Flink, Hive, Trino, PrestoDB, and many others\n",
+    "2. the [delta-rs](https://delta-io.github.io/delta-rs/) package lets you use Delta Lake in Rust or Python, e.g. with pandas, polars, Dask, Daft, DuckDB and many others\n",
+    "\n",
+    "This notebook will focus on **category (2): i.e. using Delta Lake with delta-rs**. \n",
+    "\n",
+    "For more information on the dedicated Delta connectors, refer to the [Delta Without Spark blog]().\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e01a0378-9cb2-45b6-94ed-c821ea92b595",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Make sure to install all the necessary dependencies to run the code in this notebook.\n",
+    "\n",
+    "For quick testing, you can run the `pip install` cell below. This should work fine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3cbfa4d3-b571-4aed-9421-ad2c1724b1b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # uncomment and run to pip install dependencies\n",
+    "# !pip install deltalake pandas polars getdaft dask-deltatable duckdb datafusion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df040a58-96af-4b96-9366-9766288ddf9d",
+   "metadata": {},
+   "source": [
+    "For **reliable reproducibility**, create a virtual environment with the following versions, for example using `conda` and the following specs stored in a `.yml` file:\n",
+    "\n",
+    "```\n",
+    "name: deltalake-no-spark\n",
+    "channels:\n",
+    "  - conda-forge\n",
+    "  - defaults\n",
+    "dependencies:\n",
+    "  - python=3.11\n",
+    "  - ipykernel\n",
+    "  - pandas==2.2.2\n",
+    "  - polars==0.20.30\n",
+    "  - jupyterlab\n",
+    "  - deltalake==0.17.4\n",
+    "  - dask-deltatable==0.3.1\n",
+    "  - duckdb==0.10.3\n",
+    "  - pip\n",
+    "  - pip:\n",
+    "      - getdaft\n",
+    "      - datafusion==37.1.0\n",
+    "```\n",
+    "\n",
+    "See [creating a conda env from a .yml file](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-from-an-environment-yml-file) for more information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e1e6af2-d7e0-4ec0-aee4-d94e6bf80c25",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2f30549-3c83-485a-94a7-1ceb257c9901",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "680ae033-d450-4821-9199-edb36585ffe3",
+   "metadata": {},
+   "source": [
+    "## Use Delta Lake with pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "57962c12-5b4e-4824-a304-626b6351ee8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from deltalake import write_deltalake, DeltaTable"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e21d093d-7d5c-4358-b7f9-5174a86588fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = {'first_name': ['bob', 'li', 'leah'], 'age': [47, 23, 51]}\n",
+    "data_2 = {\"first_name\": [\"suh\", \"anais\"], \"age\": [33, 68]}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ebae3e6e-703d-447f-8715-680fc3b78a34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame.from_dict(data)\n",
+    "write_deltalake(\"tmp/pandas-table\", df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "796c3b1b-c24e-490a-8a62-6f686d02ae7a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  first_name  age\n",
+      "0        bob   47\n",
+      "1         li   23\n",
+      "2       leah   51\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(DeltaTable(\"tmp/pandas-table/\").to_pandas())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0adbf996-7b4b-47be-8462-6e3d134c49c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df2 = pd.DataFrame(data_2)\n",
+    "write_deltalake(\"tmp/pandas-table\", df2, mode=\"append\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "39c7151a-7d4d-48c3-b1db-0c96dbdfbc24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  first_name  age\n",
+      "0        suh   33\n",
+      "1      anais   68\n",
+      "2        bob   47\n",
+      "3         li   23\n",
+      "4       leah   51\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(DeltaTable(\"tmp/pandas-table/\").to_pandas())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "51157986-f188-418e-8315-2f4ad53dfd8d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  first_name  age\n",
+      "0        bob   47\n",
+      "1         li   23\n",
+      "2       leah   51\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(DeltaTable(\"tmp/pandas-table/\", version=0).to_pandas())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15e184d4-f154-4e19-b2d2-986b5fbc7664",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d7ef60d-9450-4dbb-9af1-20d044dbfd0a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "947bdfc3-85a7-4123-9724-6a5d19875a2d",
+   "metadata": {},
+   "source": [
+    "## Use Delta Lake with polars"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "6c50939b-a694-4246-9366-7c7b1c5743f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import polars as pl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "03158b8d-0045-4064-9ed5-36b3238c6eaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pl.DataFrame(data)\n",
+    "df.write_delta(\"tmp/polars_table\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "b90c6154-d9d5-4214-85de-27a90905773c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "shape: (3, 2)\n",
+      "┌────────────┬─────┐\n",
+      "│ first_name ┆ age │\n",
+      "│ ---        ┆ --- │\n",
+      "│ str        ┆ i64 │\n",
+      "╞════════════╪═════╡\n",
+      "│ bob        ┆ 47  │\n",
+      "│ li         ┆ 23  │\n",
+      "│ leah       ┆ 51  │\n",
+      "└────────────┴─────┘\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(pl.read_delta(\"tmp/polars_table\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "7094bef9-96ba-4859-a38a-07cc0319466d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pl.DataFrame(data_2)\n",
+    "df.write_delta(\"tmp/polars_table\", mode=\"append\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "d335127b-e5ad-4465-adae-edce333f4ac0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "shape: (5, 2)\n",
+      "┌────────────┬─────┐\n",
+      "│ first_name ┆ age │\n",
+      "│ ---        ┆ --- │\n",
+      "│ str        ┆ i64 │\n",
+      "╞════════════╪═════╡\n",
+      "│ suh        ┆ 33  │\n",
+      "│ anais      ┆ 68  │\n",
+      "│ bob        ┆ 47  │\n",
+      "│ li         ┆ 23  │\n",
+      "│ leah       ┆ 51  │\n",
+      "└────────────┴─────┘\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(pl.read_delta(\"tmp/polars_table\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "32bd44a4-9edc-41c1-8353-17c4c0e4509f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "shape: (3, 2)\n",
+      "┌────────────┬─────┐\n",
+      "│ first_name ┆ age │\n",
+      "│ ---        ┆ --- │\n",
+      "│ str        ┆ i64 │\n",
+      "╞════════════╪═════╡\n",
+      "│ bob        ┆ 47  │\n",
+      "│ li         ┆ 23  │\n",
+      "│ leah       ┆ 51  │\n",
+      "└────────────┴─────┘\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(pl.read_delta(\"tmp/polars_table\", version=0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "013443ee-1cb4-4a49-aa3d-7f8dcb5d6271",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2256e6cc-0349-4608-aafc-e76325b038a3",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36e5d251-c5d8-4800-818f-8c980f88186d",
+   "metadata": {},
+   "source": [
+    "## Use Delta Lake with Daft"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f22d76d3-8c73-4309-ade7-ba112da67feb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import daft"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1cf7fa2a-c861-4e9a-84e9-79df8e0d59b8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                             "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "╭────────────┬───────╮\n",
+      "│\u001b[1m first_name \u001b[0m┆\u001b[1m age   \u001b[0m│\n",
+      "│\u001b[1m ---        \u001b[0m┆\u001b[1m ---   \u001b[0m│\n",
+      "│\u001b[1m Utf8       \u001b[0m┆\u001b[1m Int64 \u001b[0m│\n",
+      "╞════════════╪═══════╡\n",
+      "│ bob        ┆ 47    │\n",
+      "├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤\n",
+      "│ li         ┆ 23    │\n",
+      "├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤\n",
+      "│ leah       ┆ 51    │\n",
+      "├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤\n",
+      "│ suh        ┆ 33    │\n",
+      "├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤\n",
+      "│ anais      ┆ 68    │\n",
+      "╰────────────┴───────╯\n",
+      "\n",
+      "(Showing first 5 of 5 rows)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    }
+   ],
+   "source": [
+    "# read existing delta table\n",
+    "df = daft.read_delta_lake(\"tmp/pandas-table\")\n",
+    "print(df.collect())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a3b85356-0b04-4bf3-a157-204568731424",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                       "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "╭────────────┬───────╮\n",
+      "│\u001b[1m first_name \u001b[0m┆\u001b[1m age   \u001b[0m│\n",
+      "│\u001b[1m ---        \u001b[0m┆\u001b[1m ---   \u001b[0m│\n",
+      "│\u001b[1m Utf8       \u001b[0m┆\u001b[1m Int64 \u001b[0m│\n",
+      "╞════════════╪═══════╡\n",
+      "│ bob        ┆ 47    │\n",
+      "├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤\n",
+      "│ leah       ┆ 51    │\n",
+      "├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤\n",
+      "│ anais      ┆ 68    │\n",
+      "╰────────────┴───────╯\n",
+      "\n",
+      "(Showing first 3 of 3 rows)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    }
+   ],
+   "source": [
+    "# query data\n",
+    "print(df.where(df[\"age\"] > 40).collect())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cc5d29c-9d46-4caf-a0bf-efa8859d4e15",
+   "metadata": {},
+   "source": [
+    "❗️`daft` currently (0.2.24) supports read operations without time travel. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3eb0d94-cbdc-4ac3-b35d-2ae5b4b670fc",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "485ca5e3-a62f-411c-ab75-1e7ffa0b75aa",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c71b26dc-d5d4-4769-a17a-191987e6ec53",
+   "metadata": {},
+   "source": [
+    "## Use Delta Lake with Dask"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d2f93d3-8b6b-4c53-b82d-2436b3269161",
+   "metadata": {},
+   "source": [
+    "❗️`dask-deltatable` currently (0.3.1) only works with `deltalake<=0.13.0` so make sure to downgrade `deltalake` using the cell below. \n",
+    "\n",
+    "You will need to restart your kernel for the changes to take effect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "34b72936-67aa-4e73-b5f1-a2a3ccd246a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "# dask-deltatable works with deltalake<=0.13.0\n",
+    "!pip install deltalake==0.13.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0d2f9eb9-3878-44d9-941e-60f8349ff393",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'2024.5.1'"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import dask\n",
+    "dask.__version__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b581e14-e955-474d-bdf6-a2908a255ada",
+   "metadata": {},
+   "source": [
+    "❗️`dask-deltatable` (0.3.1) does not work with Dask's new query planner. You can disable the query planner as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e509e181-3ab7-4b53-a3f0-8eaf5ec78709",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<dask.config.set at 0x103d29150>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# uncomment and run if dask >= 2024.3.0\n",
+    "dask.config.set({'dataframe.query-planning': False})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a49e6ee2-9622-481a-a349-77795e14f181",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask_deltatable as ddt\n",
+    "import dask.dataframe as dd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3dade2a1-e853-4d84-83dd-ab6a8879d728",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = {'first_name': ['bob', 'li', 'leah'], 'age': [47, 23, 51]}\n",
+    "data_2 = {\"first_name\": [\"suh\", \"anais\"], \"age\": [33, 68]}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "40b94761-e3f9-4bc6-8294-49ec085e18c7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>first_name</th>\n",
+       "      <th>age</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>bob</td>\n",
+       "      <td>47</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>li</td>\n",
+       "      <td>23</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>leah</td>\n",
+       "      <td>51</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  first_name  age\n",
+       "0        bob   47\n",
+       "1         li   23\n",
+       "2       leah   51"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ddf = dd.from_dict(data, npartitions=1)\n",
+    "ddf.compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "7d3224d5-59ae-4827-80cf-75192547a26b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ddt.to_deltalake(\"tmp/dask-table\", ddf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "038f2ead-eeeb-4b5e-893b-cb87daac811b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# read delta table into Dask DataFrame\n",
+    "delta_path = \"tmp/dask-table/\"\n",
+    "ddf = ddt.read_deltalake(delta_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "9e5be53b-8502-46c6-8eeb-32a57f9f48d0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  first_name  age\n",
+      "0        bob   47\n",
+      "1         li   23\n",
+      "2       leah   51\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(ddf.compute())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "0b7194c7-b0b5-459a-ae2e-302c669f71b2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  first_name  age\n",
+      "0        suh   33\n",
+      "1      anais   68\n"
+     ]
+    }
+   ],
+   "source": [
+    "ddf_2 = dd.from_dict(data_2, npartitions=1)\n",
+    "print(ddf_2.compute())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "efb79562-979a-49af-b62d-de06b69810ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ddt.to_deltalake(\"tmp/dask-table\", ddf_2, mode=\"append\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "63dece4e-a8fd-44b0-bfed-cd190511bf73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# read delta table into Dask DataFrame\n",
+    "delta_path = \"tmp/dask-table/\"\n",
+    "ddf = ddt.read_deltalake(delta_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "44f2c096-20ea-4c83-bac8-69f3e38e39c3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  first_name  age\n",
+      "0        bob   47\n",
+      "1         li   23\n",
+      "2       leah   51\n",
+      "0        suh   33\n",
+      "1      anais   68\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(ddf.compute())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "0ed4e9d2-5ddf-4e9e-9878-ba97878dac2a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  first_name  age\n",
+      "0        bob   47\n",
+      "1         li   23\n",
+      "2       leah   51\n"
+     ]
+    }
+   ],
+   "source": [
+    "# read delta table into Dask DataFrame\n",
+    "delta_path = \"tmp/dask-table/\"\n",
+    "ddf = ddt.read_deltalake(delta_path, version=0)\n",
+    "print(ddf.compute())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9639caab-57f0-4ed4-a014-ddf8be5cfe42",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa13d85c-4758-475a-a2e4-465a4ea8aa63",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ae1bcc3-aec4-4547-a9a8-1efeb67c8b90",
+   "metadata": {},
+   "source": [
+    "## Use Delta Lake with DuckDB"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "de37e7d8-afc5-41b2-b68f-1ffc47da45a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import duckdb\n",
+    "from deltalake import write_deltalake, DeltaTable"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "193c7bdf-3d38-415f-b795-3051881cec7b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load in an existing delta table\n",
+    "dt = DeltaTable(\"tmp/pandas-table/\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "1f4563d2-834f-4bcc-9dac-46c65f73a2fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# convert to Arrow dataset\n",
+    "arrow_data = dt.to_pyarrow_dataset()\n",
+    "\n",
+    "# convert to DuckDB dataset\n",
+    "duck_data = duckdb.arrow(arrow_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "6635af55-ff5c-4ac2-ade4-228f992d1e1c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "┌───────┐\n",
+       "│  age  │\n",
+       "│ int64 │\n",
+       "├───────┤\n",
+       "│    68 │\n",
+       "│    51 │\n",
+       "│    47 │\n",
+       "│    33 │\n",
+       "│    23 │\n",
+       "└───────┘"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query = \"\"\"\n",
+    "select\n",
+    "  age\n",
+    "from duck_data\n",
+    "order by 1 desc\n",
+    "\"\"\"\n",
+    "\n",
+    "duckdb.query(query)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "44fcf9db-f2aa-4ed4-b2f2-e0ac811b07ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# convert result to arrow\n",
+    "arrow_table = duckdb.query(query).to_arrow_table()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "7c45d917-a813-4313-826f-68d63ce6de60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# write result to delta lake\n",
+    "write_deltalake(\n",
+    "    data=arrow_table, \n",
+    "    table_or_uri=\"tmp/duckdb-table\", \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "fe89ab97-c2dd-4962-8d0d-78245012ef6c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   age\n",
+      "0   68\n",
+      "1   51\n",
+      "2   47\n",
+      "3   33\n",
+      "4   23\n"
+     ]
+    }
+   ],
+   "source": [
+    "dt = DeltaTable(\"tmp/duckdb-table/\")\n",
+    "print(dt.to_pandas())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "ac40d3d2-02bc-4117-9f3a-14949f7c5f2d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"\"\"\n",
+    "select\n",
+    "  age\n",
+    "from duck_data\n",
+    "order by 1 desc\n",
+    "limit 3\n",
+    "\"\"\"\n",
+    "\n",
+    "arrow_table = duckdb.query(query).to_arrow_table()\n",
+    "\n",
+    "# write result to delta lake\n",
+    "write_deltalake(\n",
+    "    data=arrow_table, \n",
+    "    table_or_uri=\"tmp/duckdb-table\", \n",
+    "    mode=\"overwrite\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "8cbc0b6c-d291-437f-b5b4-d85aad4ec5eb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   age\n",
+      "0   68\n",
+      "1   51\n",
+      "2   47\n"
+     ]
+    }
+   ],
+   "source": [
+    "dt = DeltaTable(\"tmp/duckdb-table/\")\n",
+    "print(dt.to_pandas())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "f48ddee9-4a7d-44ce-b300-3fb1fa0108b3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   age\n",
+      "0   68\n",
+      "1   51\n",
+      "2   47\n",
+      "3   33\n",
+      "4   23\n"
+     ]
+    }
+   ],
+   "source": [
+    "dt = DeltaTable(\"tmp/duckdb-table/\", version=0)\n",
+    "print(dt.to_pandas())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53c16740-45d1-46a1-9778-07d2490114fc",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4131f97a-b3f3-46b4-9565-c37c2902fee7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e921b72f-7ea1-4202-84a7-26eb87a736ba",
+   "metadata": {},
+   "source": [
+    "## Use Delta Lake with Datafusion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "27ba90c7-3aa3-4636-986d-e6459d32ffe1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datafusion import SessionContext\n",
+    "from deltalake import write_deltalake, DeltaTable"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "29554ce5-c377-4a88-b8ee-01ee72887d62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ctx = SessionContext()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "6a17c32c-e8cb-4771-813c-f51e8832ea8a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table = DeltaTable(\"tmp/pandas-table/\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "df1b568b-9104-4169-b673-c4c0f3a74bd3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arrow_data = table.to_pyarrow_dataset()\n",
+    "ctx.register_dataset(\"my_delta_table\", arrow_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "efae000f-4a20-4359-af0e-c7eac9425ebc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataFrame()\n",
+       "+-----+\n",
+       "| age |\n",
+       "+-----+\n",
+       "| 68  |\n",
+       "| 51  |\n",
+       "| 47  |\n",
+       "| 33  |\n",
+       "| 23  |\n",
+       "+-----+"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query = \"select age from my_delta_table order by 1 desc\"\n",
+    "ctx.sql(query)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "e1038bb3-b056-4c22-a017-fca338f7181e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arrow_table = ctx.sql(query).to_arrow_table()\n",
+    "\n",
+    "write_deltalake(\n",
+    "    data=arrow_table, \n",
+    "    table_or_uri=\"tmp/datafusion-table\", \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "13e39444-ef01-48a8-b393-4a005b740b50",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   age\n",
+      "0   68\n",
+      "1   51\n",
+      "2   47\n",
+      "3   33\n",
+      "4   23\n"
+     ]
+    }
+   ],
+   "source": [
+    "dt = DeltaTable(\"tmp/datafusion-table/\")\n",
+    "print(dt.to_pandas())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "39b75a70-c7bc-4239-81cf-254868eb73b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"select age from my_delta_table order by 1 desc limit 3\"\n",
+    "\n",
+    "arrow_table = ctx.sql(query).to_arrow_table()\n",
+    "\n",
+    "write_deltalake(\n",
+    "    data=arrow_table, \n",
+    "    table_or_uri=\"tmp/datafusion-table\", \n",
+    "    mode=\"overwrite\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "c0b7045d-6c95-48b4-b7c9-7cfa7e38e287",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   age\n",
+      "0   68\n",
+      "1   51\n",
+      "2   47\n"
+     ]
+    }
+   ],
+   "source": [
+    "dt = DeltaTable(\"tmp/datafusion-table/\")\n",
+    "print(dt.to_pandas())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "8954836f-1e16-42a1-9bb1-f31332e9c997",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   age\n",
+      "0   68\n",
+      "1   51\n",
+      "2   47\n",
+      "3   33\n",
+      "4   23\n"
+     ]
+    }
+   ],
+   "source": [
+    "dt = DeltaTable(\"tmp/datafusion-table/\", version=0)\n",
+    "print(dt.to_pandas())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14f4a404-8cb4-4610-9d0d-f01f2a099a44",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds an example notebook of using `delta-rs` with many different query engines, as part of the "Delta without Spark" blog post.

TO DO
[ ] update link when blog post is live